### PR TITLE
Final integrations & finishing up work

### DIFF
--- a/plugins/out_pulsar/pulsar_client.c
+++ b/plugins/out_pulsar/pulsar_client.c
@@ -49,7 +49,8 @@ struct flb_pulsar_client *flb_pulsar_client_create(struct flb_output_instance
     char *service_url =
         flb_malloc(13 + strlen(ins->host.name) +
                    ceil(log10(ins->host.port)) + 1);
-    sprintf(service_url, "pulsar%s://%s:%d", (ins->use_tls ? "+ssl" : ""), ins->host.name, ins->host.port);
+    sprintf(service_url, "pulsar%s://%s:%d", (ins->use_tls ? "+ssl" : ""),
+            ins->host.name, ins->host.port);
     client->client = pulsar_client_create(service_url, client->client_config);
     flb_free(service_url);
 
@@ -100,7 +101,9 @@ pulsar_result flb_pulsar_client_produce_message(struct flb_pulsar_client *
                                                 client,
                                                 pulsar_message_t * msg)
 {
-    return pulsar_producer_send(client->producer, msg);
+    pulsar_result result = pulsar_producer_send(client->producer, msg);
+    pulsar_message_free(msg);
+    return result;
 }
 
 
@@ -113,7 +116,8 @@ int flb_pulsar_client_destroy(struct flb_pulsar_client *client)
         }
 
         if (client->producer_config) {
-            flb_pulsar_config_producer_config_destroy(client->producer_config);
+            flb_pulsar_config_producer_config_destroy(client->
+                                                      producer_config);
         }
 
         if (client->client) {

--- a/plugins/out_pulsar/pulsar_config.c
+++ b/plugins/out_pulsar/pulsar_config.c
@@ -31,8 +31,9 @@ static pulsar_compression_type convert_compression_setting_to_pulsar_enum(char
                                                                           value);
 
 pulsar_producer_configuration_t
-    * flb_pulsar_config_producer_config_create(struct flb_output_instance *
-                                              const ins)
+    *
+flb_pulsar_config_producer_config_create(struct flb_output_instance *const
+                                         ins)
 {
     pulsar_producer_configuration_t *cfg =
         pulsar_producer_configuration_create();
@@ -88,16 +89,13 @@ pulsar_producer_configuration_t
 static char *normalize_auth_method(char *const value);
 
 static void log_pulsar_msg(pulsar_logger_level_t level,
-                           const char* file,
-                           int line,
-                           const char* msg,
-                           void *ctx);
+                           const char *file,
+                           int line, const char *msg, void *ctx);
 
 pulsar_client_configuration_t *flb_pulsar_config_client_config_create(struct
-                                                                     flb_output_instance
-                                                                     *
-                                                                     const
-                                                                     ins)
+                                                                      flb_output_instance
+                                                                      *const
+                                                                      ins)
 {
     pulsar_client_configuration_t *cfg = pulsar_client_configuration_create();
 
@@ -135,12 +133,10 @@ pulsar_client_configuration_t *flb_pulsar_config_client_config_create(struct
     if (ins->use_tls) {
         pulsar_client_configuration_set_use_tls(cfg, 1);
         pulsar_client_configuration_set_tls_allow_insecure_connection(cfg,
-                                                                      !ins->
-                                                                      tls_verify);
+                                                                      !ins->tls_verify);
         if (ins->tls_ca_file) {
             pulsar_client_configuration_set_tls_trust_certs_file_path(cfg,
-                                                                      ins->
-                                                                      tls_ca_file);
+                                                                      ins->tls_ca_file);
         }
     }
 
@@ -148,14 +144,16 @@ pulsar_client_configuration_t *flb_pulsar_config_client_config_create(struct
 
 }
 
-void flb_pulsar_config_producer_config_destroy(pulsar_producer_configuration_t *cfg)
+void flb_pulsar_config_producer_config_destroy(pulsar_producer_configuration_t
+                                               * cfg)
 {
     if (cfg) {
         pulsar_producer_configuration_free(cfg);
     }
 }
 
-void flb_pulsar_config_client_config_destroy(pulsar_client_configuration_t *cfg)
+void flb_pulsar_config_client_config_destroy(pulsar_client_configuration_t *
+                                             cfg)
 {
     if (cfg) {
         pulsar_client_configuration_free(cfg);
@@ -203,15 +201,13 @@ static char *normalize_auth_method(char *const value)
 }
 
 static void log_pulsar_msg(pulsar_logger_level_t level,
-                           const char* file,
-                           int line,
-                           const char* msg,
-                           void *unused)
+                           const char *file,
+                           int line, const char *msg, void *unused)
 {
 #if FLB_LOG_DEBUG == 4 && FLB_LOG_ERROR == 1
     int flb_log_level = FLB_LOG_DEBUG - level;
 #else
-    #error "log_pulsar_msg: Log level conversion code expectations unmet."
+#error "log_pulsar_msg: Log level conversion code expectations unmet."
 #endif
 
     if (flb_log_check(flb_log_level)) {

--- a/plugins/out_pulsar/pulsar_config.h
+++ b/plugins/out_pulsar/pulsar_config.h
@@ -26,16 +26,19 @@
 #include <pulsar/c/client.h>
 
 pulsar_producer_configuration_t
-    * flb_pulsar_config_producer_config_create(struct flb_output_instance *
-                                              const ins);
+    *
+flb_pulsar_config_producer_config_create(struct flb_output_instance *const
+                                         ins);
 
 pulsar_client_configuration_t *flb_pulsar_config_client_config_create(struct
-                                                                     flb_output_instance
-                                                                     *const
-                                                                     ins);
+                                                                      flb_output_instance
+                                                                      *const
+                                                                      ins);
 
-void flb_pulsar_config_producer_config_destroy(pulsar_producer_configuration_t *cfg);
+void flb_pulsar_config_producer_config_destroy(pulsar_producer_configuration_t
+                                               * cfg);
 
-void flb_pulsar_config_client_config_destroy(pulsar_client_configuration_t *cfg);
+void flb_pulsar_config_client_config_destroy(pulsar_client_configuration_t *
+                                             cfg);
 
 #endif

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -72,9 +72,11 @@ foreach(source_file ${CHECK_PROGRAMS})
   if(FLB_WITHOUT_${source_file_we})
     message("Skipping test ${source_file_we}")
   else()
+    file(GLOB helpers helpers/${o_source_file_we}/*.c*)
     add_executable(
       ${source_file_we}
       ${source_file}
+      ${helpers}
       )
     add_sanitizers(${source_file_we})
     target_link_libraries(${source_file_we}

--- a/tests/runtime/helpers/out_pulsar/build_message.cc
+++ b/tests/runtime/helpers/out_pulsar/build_message.cc
@@ -1,0 +1,30 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "build_message.h"
+
+#include <pulsar/Message.h>
+#include <pulsar/MessageBuilder.h>
+#include "../../../../plugins/out_pulsar/pulsar-client-2.2.1/pulsar-client-cpp/lib/c/c_structs.h"
+
+void pulsar_build_message(pulsar_message_t * message)
+{
+    message->message = message->builder.build();
+}

--- a/tests/runtime/helpers/out_pulsar/build_message.h
+++ b/tests/runtime/helpers/out_pulsar/build_message.h
@@ -1,0 +1,37 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <pulsar/c/message.h>
+
+// For pulsar RT tests to examine message output, we need to "build"
+// the pulsar_message_t created in the plugin so we can read out the
+// content.
+    void pulsar_build_message(pulsar_message_t * message);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/runtime/out_pulsar.c
+++ b/tests/runtime/out_pulsar.c
@@ -23,9 +23,10 @@
 
 #include "../../plugins/out_pulsar/pulsar_context.h"
 #include "../../plugins/out_pulsar/pulsar_config.h"
+#include "helpers/out_pulsar/build_message.h"
 
 /* Test functions */
-#define FLB_PULSAR_TEST(name) void flb_test_pulsar_##name(void)
+#define FLB_PULSAR_TEST(name) static void flb_test_pulsar_##name(void)
 
 FLB_PULSAR_TEST(producer_config_defaults);
 FLB_PULSAR_TEST(producer_config_send_timeout);
@@ -42,53 +43,105 @@ FLB_PULSAR_TEST(client_config_auth_token);
 FLB_PULSAR_TEST(client_config_auth_custom);
 FLB_PULSAR_TEST(client_config_with_tls_on_defaults);
 FLB_PULSAR_TEST(client_config_with_tls_options);
-
-#define FLB_PULSAR_TEST_ENTRY(name) { "flb_test_pulsar_" #name, flb_test_pulsar_##name }
+FLB_PULSAR_TEST(msgs_are_sent_as_json);
+FLB_PULSAR_TEST(msgs_that_fail_to_send_with_certain_errors_are_retried);
+FLB_PULSAR_TEST(msgs_that_fail_to_send_with_certain_errors_are_dropped);
 
 /* Test list */
+#define FLB_PULSAR_TEST_ENTRY(name) { "flb_test_pulsar_" #name, flb_test_pulsar_##name }
+
 TEST_LIST = {
     FLB_PULSAR_TEST_ENTRY(producer_config_defaults),
-        FLB_PULSAR_TEST_ENTRY(producer_config_send_timeout),
-        FLB_PULSAR_TEST_ENTRY(producer_config_compression_type_none),
-        FLB_PULSAR_TEST_ENTRY(producer_config_compression_type_zlib),
-        FLB_PULSAR_TEST_ENTRY(producer_config_compression_type_lz4),
-        FLB_PULSAR_TEST_ENTRY(producer_config_compression_type_invalid),
-        FLB_PULSAR_TEST_ENTRY(producer_config_max_pending_messages),
-        FLB_PULSAR_TEST_ENTRY(producer_config_batching_settings),
-        FLB_PULSAR_TEST_ENTRY(client_config_defaults),
-        FLB_PULSAR_TEST_ENTRY(client_config_auth_tls),
-        FLB_PULSAR_TEST_ENTRY(client_config_auth_athenz),
-        FLB_PULSAR_TEST_ENTRY(client_config_auth_token),
-        FLB_PULSAR_TEST_ENTRY(client_config_auth_custom),
-        FLB_PULSAR_TEST_ENTRY(client_config_with_tls_on_defaults),
-        FLB_PULSAR_TEST_ENTRY(client_config_with_tls_options), {
-    NULL, NULL}
+    FLB_PULSAR_TEST_ENTRY(producer_config_send_timeout),
+    FLB_PULSAR_TEST_ENTRY(producer_config_compression_type_none),
+    FLB_PULSAR_TEST_ENTRY(producer_config_compression_type_zlib),
+    FLB_PULSAR_TEST_ENTRY(producer_config_compression_type_lz4),
+    FLB_PULSAR_TEST_ENTRY(producer_config_compression_type_invalid),
+    FLB_PULSAR_TEST_ENTRY(producer_config_max_pending_messages),
+    FLB_PULSAR_TEST_ENTRY(producer_config_batching_settings),
+    FLB_PULSAR_TEST_ENTRY(client_config_defaults),
+    FLB_PULSAR_TEST_ENTRY(client_config_auth_tls),
+    FLB_PULSAR_TEST_ENTRY(client_config_auth_athenz),
+    FLB_PULSAR_TEST_ENTRY(client_config_auth_token),
+    FLB_PULSAR_TEST_ENTRY(client_config_auth_custom),
+    FLB_PULSAR_TEST_ENTRY(client_config_with_tls_on_defaults),
+    FLB_PULSAR_TEST_ENTRY(client_config_with_tls_options),
+    FLB_PULSAR_TEST_ENTRY(msgs_are_sent_as_json),
+    FLB_PULSAR_TEST_ENTRY(msgs_that_fail_to_send_with_certain_errors_are_retried),
+    FLB_PULSAR_TEST_ENTRY(msgs_that_fail_to_send_with_certain_errors_are_dropped),
+    { NULL, NULL}
 };
 
-pulsar_result pubok(struct flb_pulsar_context *context,
-                    pulsar_message_t * msg)
+
+static pulsar_message_t *message_produced = NULL;
+static int pub_return = pulsar_result_Ok;
+
+static pulsar_result mock_publish(struct flb_pulsar_context *context,
+                                  pulsar_message_t *msg)
+{
+    pulsar_result result = pulsar_result_Ok;
+
+    if (pub_return != pulsar_result_Ok) {
+        result = pub_return;
+        pub_return = pulsar_result_Ok;
+        return result;
+    }
+
+    if (msg) {
+        pulsar_build_message(msg);
+    }
+
+    if (!message_produced) {
+        message_produced = msg;
+    }
+    else {
+        result = pulsar_result_ProducerQueueIsFull;
+    }
+
+    return result;
+}
+
+static pulsar_result mock_connect(struct flb_pulsar_context *context)
 {
     return pulsar_result_Ok;
 }
 
-pulsar_result connectok(struct flb_pulsar_context * context)
-{
-    return pulsar_result_Ok;
-}
-
-struct flb_pulsar_context mock_context()
+static struct flb_pulsar_context mock_context()
 {
     struct flb_pulsar_context mock;
-    mock.publish_fn = &pubok;
-    mock.connect_fn = &connectok;
+    mock.publish_fn = &mock_publish;
+    mock.connect_fn = &mock_connect;
     return mock;
 }
 
-static flb_ctx_t *ctx = NULL;
-
-struct flb_output_instance *prepare_output_instance()
+static void timeout_next_message_production()
 {
-    int in_ffd;
+    pub_return = pulsar_result_Timeout;
+}
+
+static void fail_next_message_production()
+{
+    pub_return = pulsar_result_UnknownError;
+}
+
+static pulsar_message_t *last_message(void)
+{
+    return message_produced;
+}
+
+static void reset_last_message(void)
+{
+    if (message_produced) {
+        pulsar_message_free(message_produced);
+        message_produced = NULL;
+    }
+}
+
+static flb_ctx_t *ctx = NULL;
+static int in_ffd = 0;
+
+static struct flb_output_instance *prepare_output_instance()
+{
     int out_ffd;
 
     ctx = flb_create();
@@ -106,11 +159,14 @@ struct flb_output_instance *prepare_output_instance()
                               struct flb_output_instance, _head);
 }
 
-void tear_down(void)
+static void tear_down(void)
 {
     if (ctx) {
         flb_destroy(ctx);
     }
+    in_ffd = 0;
+
+    reset_last_message();
 }
 
 FLB_PULSAR_TEST(producer_config_defaults)
@@ -153,10 +209,10 @@ FLB_PULSAR_TEST(producer_config_compression_type_none)
 {
     struct flb_output_instance *instance = prepare_output_instance();
 
-    pulsar_producer_configuration_t *producer_cfg;
-
     flb_output_set_property(instance, "compression_type", "None");
-    producer_cfg = flb_pulsar_config_producer_config_create(instance);
+    pulsar_producer_configuration_t *producer_cfg =
+        flb_pulsar_config_producer_config_create(instance);
+
     TEST_CHECK(pulsar_producer_configuration_get_compression_type
                (producer_cfg) == pulsar_CompressionNone);
 
@@ -168,10 +224,10 @@ FLB_PULSAR_TEST(producer_config_compression_type_zlib)
 {
     struct flb_output_instance *instance = prepare_output_instance();
 
-    pulsar_producer_configuration_t *producer_cfg;
-
     flb_output_set_property(instance, "compression_type", "zLIB");
-    producer_cfg = flb_pulsar_config_producer_config_create(instance);
+    pulsar_producer_configuration_t *producer_cfg =
+        flb_pulsar_config_producer_config_create(instance);
+
     TEST_CHECK(pulsar_producer_configuration_get_compression_type
                (producer_cfg) == pulsar_CompressionZLib);
 
@@ -183,9 +239,10 @@ FLB_PULSAR_TEST(producer_config_compression_type_lz4)
 {
     struct flb_output_instance *instance = prepare_output_instance();
 
-    pulsar_producer_configuration_t *producer_cfg;
     flb_output_set_property(instance, "compression_type", "lz4");
-    producer_cfg = flb_pulsar_config_producer_config_create(instance);
+    pulsar_producer_configuration_t *producer_cfg =
+        flb_pulsar_config_producer_config_create(instance);
+
     TEST_CHECK(pulsar_producer_configuration_get_compression_type
                (producer_cfg) == pulsar_CompressionLZ4);
 
@@ -197,9 +254,10 @@ FLB_PULSAR_TEST(producer_config_compression_type_invalid)
 {
     struct flb_output_instance *instance = prepare_output_instance();
 
-    pulsar_producer_configuration_t *producer_cfg;
     flb_output_set_property(instance, "compression_type", "something-bogus");
-    producer_cfg = flb_pulsar_config_producer_config_create(instance);
+    pulsar_producer_configuration_t *producer_cfg =
+        flb_pulsar_config_producer_config_create(instance);
+
     TEST_CHECK(pulsar_producer_configuration_get_compression_type
                (producer_cfg) == pulsar_CompressionLZ4);
 
@@ -211,9 +269,10 @@ FLB_PULSAR_TEST(producer_config_max_pending_messages)
 {
     struct flb_output_instance *instance = prepare_output_instance();
 
-    pulsar_producer_configuration_t *producer_cfg;
     flb_output_set_property(instance, "max_pending_messages", "42");
-    producer_cfg = flb_pulsar_config_producer_config_create(instance);
+    pulsar_producer_configuration_t *producer_cfg =
+        flb_pulsar_config_producer_config_create(instance);
+
     TEST_CHECK(pulsar_producer_configuration_get_max_pending_messages
                (producer_cfg) == 42);
 
@@ -225,11 +284,11 @@ FLB_PULSAR_TEST(producer_config_batching_settings)
 {
     struct flb_output_instance *instance = prepare_output_instance();
 
-    pulsar_producer_configuration_t *producer_cfg;
     flb_output_set_property(instance, "batching_enabled", "on");
     flb_output_set_property(instance, "batching_max_publish_delay_ms", "314");
+    pulsar_producer_configuration_t *producer_cfg =
+        flb_pulsar_config_producer_config_create(instance);
 
-    producer_cfg = flb_pulsar_config_producer_config_create(instance);
     TEST_CHECK(pulsar_producer_configuration_get_batching_enabled
                (producer_cfg) == 1);
     TEST_CHECK(pulsar_producer_configuration_get_batching_max_publish_delay_ms
@@ -248,7 +307,7 @@ FLB_PULSAR_TEST(client_config_defaults)
 
     TEST_CHECK_(client_cfg != NULL,
                 "This test should check that auth method defaults to none, "
-                "but there is no method to get the auth method from the config.");
+                "but the Pulsar C API provides no means to do so.");
     TEST_CHECK(pulsar_client_configuration_is_use_tls(client_cfg) == 0);
 
     pulsar_client_configuration_free(client_cfg);
@@ -279,6 +338,7 @@ FLB_PULSAR_TEST(client_config_auth_token)
     flb_output_set_property(instance, "auth_method", "toKeN");
     flb_output_set_property(instance, "auth_params",
                             "I'm a token auth param");
+
     pulsar_client_configuration_t *client_cfg =
         flb_pulsar_config_client_config_create(instance);
 
@@ -323,7 +383,7 @@ FLB_PULSAR_TEST(client_config_auth_custom)
         flb_pulsar_config_client_config_create(instance);
 
     TEST_CHECK_(client_cfg != NULL,
-                "This test should check that auth method supports a custom path,"
+                "This test should check that auth method supports a custom lib,"
                 "but the Pulsar C API provides no means to do so.");
 
     pulsar_client_configuration_free(client_cfg);
@@ -333,10 +393,11 @@ FLB_PULSAR_TEST(client_config_auth_custom)
 FLB_PULSAR_TEST(client_config_with_tls_on_defaults)
 {
     struct flb_output_instance *instance = prepare_output_instance();
-    flb_output_set_property(instance, "tls", "on");
 
+    flb_output_set_property(instance, "tls", "on");
     pulsar_client_configuration_t *client_cfg =
         flb_pulsar_config_client_config_create(instance);
+
     TEST_CHECK(pulsar_client_configuration_is_use_tls(client_cfg) == 1);
     TEST_CHECK(pulsar_client_configuration_is_tls_allow_insecure_connection
                (client_cfg) == 0);
@@ -351,12 +412,13 @@ FLB_PULSAR_TEST(client_config_with_tls_on_defaults)
 FLB_PULSAR_TEST(client_config_with_tls_options)
 {
     struct flb_output_instance *instance = prepare_output_instance();
+
     flb_output_set_property(instance, "tls", "on");
     flb_output_set_property(instance, "tls.verify", "off");
     flb_output_set_property(instance, "tls.ca_file", "/path/to/certs");
-
     pulsar_client_configuration_t *client_cfg =
         flb_pulsar_config_client_config_create(instance);
+
     TEST_CHECK(pulsar_client_configuration_is_use_tls(client_cfg) == 1);
     TEST_CHECK(pulsar_client_configuration_is_tls_allow_insecure_connection
                (client_cfg) == 1);
@@ -366,4 +428,101 @@ FLB_PULSAR_TEST(client_config_with_tls_options)
 
     pulsar_client_configuration_free(client_cfg);
     tear_down();
+}
+
+static int startup(struct flb_output_instance *instance)
+{
+    struct flb_pulsar_context ctxt = mock_context();
+    flb_output_set_context(instance, &ctxt);
+    flb_output_set_property(instance, "retry_limit", "false");
+
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Daemon", "false", NULL);
+    return TEST_CHECK(flb_start(ctx) == 0);
+}
+
+static void shut_down(void)
+{
+    flb_stop(ctx);
+    tear_down();
+}
+
+FLB_PULSAR_TEST(msgs_are_sent_as_json)
+{
+    struct flb_output_instance *instance = prepare_output_instance();
+
+    if (startup(instance)) {
+        char *str = "[1, {\"key\":\"value\"}]";
+        flb_lib_push(ctx, in_ffd, str, strlen(str));
+
+        sleep(1);
+
+        if (TEST_CHECK(last_message() != NULL)) {
+            TEST_CHECK(strcmp("{\"key\":\"value\"}",
+                              (char *)
+                              pulsar_message_get_data(last_message())) == 0);
+        }
+    }
+
+    shut_down();
+}
+
+FLB_PULSAR_TEST(msgs_that_fail_to_send_with_certain_errors_are_retried)
+{
+    struct flb_output_instance *instance = prepare_output_instance();
+
+    if (startup(instance)) {
+        timeout_next_message_production();
+
+        char *str = "[1, {\"key\":\"value\"}]";
+        flb_lib_push(ctx, in_ffd, str, strlen(str));
+
+        sleep(1);
+
+        TEST_CHECK(last_message() == NULL);
+
+        flb_debug("[out_pulsar_test] waiting for message retry");
+        for (int seconds = 0; seconds < 15; ++seconds) {
+            sleep(1);
+            if (last_message()) {
+                break;
+            }
+        }
+
+        if (TEST_CHECK(last_message() != NULL)) {
+            TEST_CHECK(strcmp("{\"key\":\"value\"}",
+                              (char *)
+                              pulsar_message_get_data(last_message())) == 0);
+        }
+    }
+
+    shut_down();
+}
+
+FLB_PULSAR_TEST(msgs_that_fail_to_send_with_certain_errors_are_dropped)
+{
+    struct flb_output_instance *instance = prepare_output_instance();
+
+    if (startup(instance)) {
+        fail_next_message_production();
+
+        char *msg1 = "[1, {\"v\":\"1\"}]";
+        flb_lib_push(ctx, in_ffd, msg1, strlen(msg1));
+
+        sleep(1);
+
+        TEST_CHECK(last_message() == NULL);
+
+        char *msg2 = "[2, {\"v\":\"2\"}]";
+        flb_lib_push(ctx, in_ffd, msg2, strlen(msg2));
+
+        sleep(1);
+
+        if (TEST_CHECK(last_message() != NULL)) {
+            TEST_CHECK(strcmp("{\"v\":\"2\"}",
+                              (char *)
+                              pulsar_message_get_data(last_message())) == 0);
+        }
+    }
+
+    shut_down();
 }


### PR DESCRIPTION
Depends on and is based on #5 

@kramasamy This pull is a work in progress and represents the work being done on:

- [x] [Logging](https://github.com/streamlio/fluent-bit/projects/1#card-17402086)
- [x] [Robust message production](https://github.com/streamlio/fluent-bit/projects/1#card-17402095)
- [x] [Valgrind testing + fixes](https://github.com/streamlio/fluent-bit/projects/1#card-17532892)

## Current Valgrind summary
Key takeway: we are leaking some memory, but it doesn't appear to be increasing based on the duration of the run, so it's must all be allocations at startup that aren't deallocated. Not sure how much effort to put into that -- the OS is really good at freeing up memory.

### Baseline `fluent-bit -i cpu -o null`
```
==12745== HEAP SUMMARY:
==12745==     in use at exit: 3,176 bytes in 47 blocks
==12745==   total heap usage: 4,780 allocs, 4,733 frees, 13,713,784 bytes allocated
==12745== 
==12745== LEAK SUMMARY:
==12745==    definitely lost: 0 bytes in 0 blocks
==12745==    indirectly lost: 0 bytes in 0 blocks
==12745==      possibly lost: 0 bytes in 0 blocks
==12745==    still reachable: 3,176 bytes in 47 blocks
==12745==         suppressed: 0 bytes in 0 blocks
==12745== Reachable blocks (those to which a pointer was found) are not shown.
==12745== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==12745== 
==12745== For counts of detected and suppressed errors, rerun with: -v
==12745== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

### Pulsar run 1 `fluent-bit -i cpu -o pulsar`
```
==11449== HEAP SUMMARY:
==11449==     in use at exit: 355,108 bytes in 155 blocks
==11449==   total heap usage: 11,707 allocs, 11,552 frees, 11,575,582 bytes allocated
==11449==
==11449== LEAK SUMMARY:
==11449==    definitely lost: 108 bytes in 1 blocks
==11449==    indirectly lost: 0 bytes in 0 blocks
==11449==      possibly lost: 137,004 bytes in 32 blocks
==11449==    still reachable: 217,996 bytes in 122 blocks
==11449==         suppressed: 0 bytes in 0 blocks
==11449== Reachable blocks (those to which a pointer was found) are not shown.
==11449== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==11449== 
==11449== For counts of detected and suppressed errors, rerun with: -v
==11449== ERROR SUMMARY: 33 errors from 33 contexts (suppressed: 0 from 0)
```

### Pulsar run 2 (run ~twice as long):
```
==11968== HEAP SUMMARY:
==11968==     in use at exit: 355,108 bytes in 155 blocks
==11968==   total heap usage: 15,751 allocs, 15,596 frees, 24,444,630 bytes allocated
==11968== 
==11968== LEAK SUMMARY:
==11968==    definitely lost: 108 bytes in 1 blocks
==11968==    indirectly lost: 0 bytes in 0 blocks
==11968==      possibly lost: 137,004 bytes in 32 blocks
==11968==    still reachable: 217,996 bytes in 122 blocks
==11968==         suppressed: 0 bytes in 0 blocks
==11968== Reachable blocks (those to which a pointer was found) are not shown.
==11968== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==11968== 
==11968== For counts of detected and suppressed errors, rerun with: -v
==11968== ERROR SUMMARY: 33 errors from 33 contexts (suppressed: 0 from 0)
```