### PR TITLE
Added libcurl4-openssl-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update && \
       libsasl2-dev \
       pkg-config \
       libsystemd-dev \
-      zlib1g-dev
+      zlib1g-dev \
+      libcurl4-openssl-dev
 
 # Apache Pulsar pre-requisites
 RUN apt-get update && \


### PR DESCRIPTION
Added libcurl4-openssl-dev to resolve

`error while loading shared libraries: libcurl.so.4: cannot open shared object file: No such file or directory` error